### PR TITLE
Relax omniauth-oauth2 dependency

### DIFF
--- a/omniauth-eventbrite.gemspec
+++ b/omniauth-eventbrite.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.1.0'
+  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.0'
   s.add_development_dependency 'rspec', '~> 2.7.0'
   s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
The outdated dependency is causing dependency resolution errors between this provider and others. Please consider updating the dependency. All specs are still passing, so it should just require a version bump and re-release to RubyGems.

Note: I first created a bump PR to 1.2.0, but realized that there had been one for 1.1.0 as well. I opted instead to relax the dependency to ~> 1.0, since Semantic Versioning should be followed on omniauth-oauth2. Feel free to pick 1.2.0 over the relaxing to 1.0.