### PR TITLE
Support more recent versions of omniauth-oauth2

### DIFF
--- a/omniauth-eventbrite.gemspec
+++ b/omniauth-eventbrite.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |spec|
                   omniauth-eventbrite.gemspec) + Dir['lib/**/*.rb']
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'omniauth-oauth2', '~> 1.0'
+  spec.add_dependency 'omniauth-oauth2', '~> 1.2'
   spec.add_development_dependency 'bundler', '~> 1.0'
 end


### PR DESCRIPTION
This change will allow this gem to work with more recent versions of omniauth-oauth2.