### PR TITLE
Update gemspec and version number

### DIFF
--- a/lib/omniauth/eventbrite/version.rb
+++ b/lib/omniauth/eventbrite/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Eventbrite
-    VERSION = '0.0.6'
+    VERSION = '0.0.7'
   end
 end

--- a/omniauth-eventbrite.gemspec
+++ b/omniauth-eventbrite.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |spec|
                   omniauth-eventbrite.gemspec) + Dir['lib/**/*.rb']
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'omniauth-oauth2', '~> 1.0'
-  spec.add_development_dependency 'bundler', '~> 1.0'
+  spec.add_dependency 'omniauth-oauth2', '>= 1.0', '< 3'
+  spec.add_development_dependency 'bundler', '>= 1.0', '< 3'
 end


### PR DESCRIPTION
Required to update omniauth to v2, which is in turn mandatory for migrating to Ruby 3